### PR TITLE
Auto-detect base URL to avoid 404s

### DIFF
--- a/app/config/Config.php
+++ b/app/config/Config.php
@@ -10,8 +10,12 @@ const DB_PASS = '';
 const DB_NAME = 'trms';
 const DB_PORT = 3306;
 
-// Base URL
-const BASE_URL = 'http://localhost/trms/public/';
+// Base URL - dynamically determined so the app works from any directory
+$scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+$host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$scriptDir = rtrim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? '/')), '/');
+$baseUrl = $scheme . '://' . $host . ($scriptDir === '' ? '' : $scriptDir) . '/';
+define('BASE_URL', $baseUrl);
 
 // CSRF token name
 const CSRF_TOKEN_NAME = '_csrf';


### PR DESCRIPTION
## Summary
- derive the application's base URL at runtime so it can serve correctly from any directory

## Testing
- `php -l app/config/Config.php`
- `php -S localhost:8000 -t public >/tmp/server.log 2>&1 &`
- `curl -i http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_b_68ac2b3311b8832e8744fe2563f89400