### PR TITLE
Add admin layout and sidebar partial

### DIFF
--- a/app/views/layouts/admin.php
+++ b/app/views/layouts/admin.php
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>TRMS Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="<?= url('assets/css/style.css'); ?>" rel="stylesheet">
+</head>
+<body>
+    <div class="with-sidebar">
+        <?php include __DIR__ . '/../partials/sidebar.php'; ?>
+        <main class="content-area p-4">
+            <?= $content ?>
+        </main>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="<?= url('assets/js/app.js'); ?>"></script>
+</body>
+</html>

--- a/app/views/partials/sidebar.php
+++ b/app/views/partials/sidebar.php
@@ -1,0 +1,46 @@
+<nav class="app-sidebar sidebar-nav p-3 border-end">
+    <a href="<?= url('admin/dashboard'); ?>" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-decoration-none">
+        <span class="fs-4">FilStar</span>
+    </a>
+    <hr>
+    <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+            <a href="<?= url('admin/dashboard'); ?>" class="nav-link">
+                <i class="bi bi-speedometer2 me-2"></i>Dashboard
+            </a>
+        </li>
+        <li>
+            <a href="#" class="nav-link">
+                <i class="bi bi-truck me-2"></i>Trucks
+            </a>
+        </li>
+        <li>
+            <a href="#" class="nav-link">
+                <i class="bi bi-bag-check me-2"></i>Purchase Requests
+            </a>
+        </li>
+        <li>
+            <a href="#" class="nav-link">
+                <i class="bi bi-wrench-adjustable-circle me-2"></i>Work Orders
+            </a>
+        </li>
+        <li>
+            <a href="#" class="nav-link">
+                <i class="bi bi-gear me-2"></i>Settings
+            </a>
+        </li>
+        <li class="mt-3">
+            <button class="btn btn-toggle align-items-center rounded collapsed w-100 text-start d-flex" data-bs-toggle="collapse" data-bs-target="#users-collapse" aria-expanded="true">
+                <i class="bi bi-people me-2"></i>
+                <span class="flex-grow-1 text-start">Users</span>
+                <i class="bi bi-chevron-right ms-auto"></i>
+            </button>
+            <div class="collapse show" id="users-collapse">
+                <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small ps-4">
+                    <li><a href="#" class="nav-link">Mechanics</a></li>
+                    <li><a href="#" class="nav-link active">Staff</a></li>
+                </ul>
+            </div>
+        </li>
+    </ul>
+</nav>

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -65,24 +65,17 @@ body {
   background: transparent;
   font-weight: 600;
   color: #212529;
+  display: flex;
+  align-items: center;
 }
 .btn-toggle:hover {
   background: rgba(13, 110, 253, 0.08);
 }
-
-/* Simple chevron indicator (no icon library required) */
-.btn-toggle .chev {
-  display: inline-block;
-  width: 0.65em;
-  height: 0.65em;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: rotate(45deg);
+.btn-toggle .bi {
   transition: transform 0.2s ease;
-  margin-left: 0.5rem;
 }
-.btn-toggle:not(.collapsed) .chev {
-  transform: rotate(225deg); /* down */
+.btn-toggle[aria-expanded="true"] .bi-chevron-right {
+  transform: rotate(90deg);
 }
 
 /* Optional dark mode if using Bootstrap's data-bs-theme="dark" */


### PR DESCRIPTION
## Summary
- Integrate Bootstrap layout that includes reusable sidebar partial
- Style sidebar with border, collapsible Users section, and rotating chevron
- Remove unused Reports link and tidy markup

## Testing
- `php -l app/views/layouts/admin.php`
- `php -l app/views/partials/sidebar.php`


------
https://chatgpt.com/codex/tasks/task_b_68ac43b8cabc832e9a1e2a5c59cb7488